### PR TITLE
Remove plugin unload from rsp_off

### DIFF
--- a/rsp_off.cfg
+++ b/rsp_off.cfg
@@ -48,10 +48,8 @@ tf_tournament_classlimit_spy "-1"
 sv_allow_color_correction "1"
 
 
-// Unloading the plugin (if exists)
+// Disabling the plugin (if it exists)
 melee 0
-sm plugins unload melee
-
 
 servercfgfile "server.cfg"
 say "Reloading your server default configuration."


### PR DESCRIPTION
Unloading a server's plugins is generally not a good idea